### PR TITLE
Update warehouse.go

### DIFF
--- a/pkg/snowflake/warehouse.go
+++ b/pkg/snowflake/warehouse.go
@@ -40,7 +40,7 @@ func (wb *WarehouseBuilder) Create() *CreateBuilder {
 
 // ShowParameters returns the query to show the parameters for the warehouse
 func (wb *WarehouseBuilder) ShowParameters() string {
-	return fmt.Sprintf("SHOW PARAMETERS IN WAREHOUSE %q", wb.Builder.name)
+	return fmt.Sprintf("SHOW PARAMETERS IN WAREHOUSE %v", wb.Builder.name)
 }
 
 func Warehouse(name string) *WarehouseBuilder {


### PR DESCRIPTION
Fix issue #1104

When I try to use the command SHOW PARAMETERS without double quotes I receive an error, the problem is the print where I did the change. From my fork now it is working well.

The ignore quote cant be added during the process in the terraform plan (terraform opens multiple sessions in snowflake) that's why we need to fix them.


<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->
https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1104

* 